### PR TITLE
fix: typo

### DIFF
--- a/rfcs/0002-ckb/0002-ckb.md
+++ b/rfcs/0002-ckb/0002-ckb.md
@@ -107,7 +107,7 @@ The CKB programming model consists of three parts:
 
 In this model, decentralization application logic is split into two parts as generation and verification, running at different places. State generation logic runs off-chain at the client side, new states are packaged into transactions and broadcasted to the entire network. CKB transaction has an inputs/outputs based structure as in Bitcoin. The client puts generated new state in transaction outputs, which is called cells in CKB. Cells are the primary state storage units in CKB. Transaction inputs are references to previous outputs, along with proofs to unlock them. Cells are assets owned by users and must follow associated application logic specified by scripts. CKB VM executes those scripts and verifies proofs in inputs to make sure the user is permitted to use referenced cells, and state transition is valid under specified application logic. In this way, all nodes in the network verify new states are valid and keep them in custody.
 
-State in CKB are first-class citizens, they are included in transactions and blocks and synchronized directly among nodes. Although the programming model is stateful, scripts running in CKV VM are pure functions with no internal state, which makes CKB scripts deterministic, parallel execution friendly and easy to compose.
+State in CKB are first-class citizens, they are included in transactions and blocks and synchronized directly among nodes. Although the programming model is stateful, scripts running in CKB VM are pure functions with no internal state, which makes CKB scripts deterministic, parallel execution friendly and easy to compose.
 
 ### 4.1 State Generation and Verification
 
@@ -143,7 +143,7 @@ Cells are the primary state units in CKB, and users can put arbitrary states in 
 - `type`: State verification script.
 - `lock`: Script that represents the ownership of the cell. Owners of cells can transfer cells to others.
 
-A cell is an immutable object, as no one can modify it after creation. Every cell can only be used once - it cannot be used as inputs for two different transactions. Cell ‘updates’ mark previous cells as history and create new cells with the same capacity to replace them. By construct and send transactions, users provide new cells with new states in it and invalidate previous cells storing old states atomically. The set of all current (or live) cells represents the latest version of all common knowledge in CKB, and the set of history (or dead) cells represents all histories versions of common knowledge.
+A cell is an immutable object, as no one can modify it after creation. Every cell can only be used once - it cannot be used as inputs for two different transactions. Cell ‘updates’ mark previous cells as history and create new cells with the same capacity to replace them. By construct and send transactions, users provide new cells with new states in it and invalidate previous cells storing old states atomically. The set of all current (or live) cells represents the latest version of all common knowledge in CKB, and the set of history (or dead) cells represents all historical versions of common knowledge.
 
 CKB allows users to transfer cell capacity all at once, or transfer only a fraction of a cell's capacity, which leads to more cells created (e.g., a cell with capacity=10 becomes two cells with capacity=5).
 


### PR DESCRIPTION
`CKV` -> `CKB`
`histories` -> `historical`