### PR TITLE
Obsolete 0008 Temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The maintainers of RFCs will review the proposal, ask if there's any objections,
 | [5](rfcs/0005-priviledged-mode) | [Privileged architecture support for CKB VM](rfcs/0005-priviledged-mode/0005-priviledged-mode.md) | Xuejie Xiao | Informational | Draft |
 | [6](rfcs/0006-merkle-tree) | [Merkle Tree for Static Data](rfcs/0006-merkle-tree/0006-merkle-tree.md) | Ke Wang | Standards Track | Proposal |
 | [7](rfcs/0007-scoring-system-and-network-security) | [P2P Scoring System And Network Security](rfcs/0007-scoring-system-and-network-security/0007-scoring-system-and-network-security.md) | Jinyang Jiang | Standards Track | Proposal |
-| [8](rfcs/0008-serialization) | [Serialization](rfcs/0008-serialization/0008-serialization.md) | Ian Yang | Standards Track | Proposal |
+| [8](rfcs/0008-serialization) | [Serialization](rfcs/0008-serialization/0008-serialization.md) | Ian Yang | Standards Track | Obsolete |
 | [9](rfcs/0009-vm-syscalls) | [VM Syscalls](rfcs/0009-vm-syscalls/0009-vm-syscalls.md) | Xuejie Xiao | Standards Track | Proposal |
 | [11](rfcs/0011-serialization) | [Transaction Filter](rfcs/0011-transaction-filter-protocol/0011-transaction-filter-protocol.md) | Quake Wang | Standards Track | Proposal |
 | [12](rfcs/00012-node-discovery) | [Node Discovery](rfcs/0012-node-discovery/0012-node-discovery.md) | Linfeng Qian, Jinyang Jiang | Standards Track | Proposal |

--- a/rfcs/0008-serialization/0008-serialization.md
+++ b/rfcs/0008-serialization/0008-serialization.md
@@ -1,11 +1,14 @@
 ---
 Number: "0008"
 Category: Standards Track
-Status: Proposal
+Status: Obsolete
 Author: Ian Yang
 Organization: Nervos Foundation
 Created: 2018-12-17
 ---
+
+Obsoleting reason: we are developing a new serialization method to replace
+FlatBuffers.
 
 # Serialization
 


### PR DESCRIPTION
Keep this PR to remind that 0008 is obsoleted. We'll replace it with a new serialization method.