### PR TITLE
propose POA testnet

### DIFF
--- a/rfcs/0000-poa-testnet/0000-poa-testnet.md
+++ b/rfcs/0000-poa-testnet/0000-poa-testnet.md
@@ -1,0 +1,124 @@
+---
+Number: "0000"
+Category: <TBD>
+Status: <TBD>
+Author: <TBD>
+Organization: <TBD>
+Created: <TBD>
+---
+
+# POA testnet
+
+## Motivation
+
+The original intention of aggron testnet is to provide a development-friendly testnet,
+ allow develops to deploy and test contracts, it's supposed to be similar to mainnet and provide stable services.
+
+However, the mining power on aggron is very unstable[chars](https://explorer.nervos.org/aggron/charts), Obviously for a reasonable miner there is no incitive to mine the testnet coins, and any new miner or mining pool join the testnet will speedup the block produces time temporally, then they leave, the testnet become extremely slow, the avg block time becomes few minutes or even longer.
+
+A POW blockchain only works when the miner has economic incentives. So we propose a new POA consensus testnet to serve contract development purposes.
+
+We expect the new POA testnet to be long term stable, the testnet should be just like the mainnet without using POW. A contract developer should feel no difference when developing on POA testnet and mainnet.
+
+In the purpose we design the POA testnet with the following principles:
+
+* There should be a dynamic group of validators to maintain the POA network, each validator can submit block and vote. With enough votes, the network can allow new validators to join or evict a exists validators.
+* The network cannot be halted or concerned by minority malicious validators, malicious validators should be eventually evicted by majority honest validators.
+* The other part of the network should be the same as the mainnet(unless block header may need some extract context to do verification).
+
+## POA protocol
+
+For easy to describe the protocol, we define the following variables:
+
+* `VALIDATOR_COUNT` - Number of current validators, this value changed due to new validators join or old validator leaves.
+* `ATTEST_INTERVAL` - A validator cannot attest two blocks within `ATTEST_INTERVAL` number. For example, a validator who attest block (6) must wait for at least `ATTEST_INTERVAL` blocks to do next attest: block (6 + `ATTEST_INTERVAL` + 1). Notice when the `VALIDATOR_COUNT` <= `ATTEST_INTERVAL`, the POA testnet will stuck forever due to no validators can attest a new block.
+* `BLOCK_INTERVAL` - the interval of blocks, set to 8 seconds.
+* `VOTE_LIMIT` - The least votes to make a new validator join or to evict an old validator, should be at least `VALIDATOR_COUNT / 2 + 1`.
+
+## attest a new block
+
+let's pre assuming the validator list already exists. Our protocol is simple enough that the change of validator list will not affect our purpose, we can assume the validator list is fixed for now.
+
+Validators use a round-robin style to attest blocks.
+For block `n`, the validator which index equals `n % VALIDATOR_COUNT` suppose to be the attester. However, a validator can fail to produce a block in time due to network congestion or other reasons, in this case, other validators should produce the block `n`.
+
+Validators can use a simple strategy to achieve this:
+
+* If `INDEX == n % VALIDATOR_COUNT`, wait for `BLOCK_INTERVAL` seconds then produce a new block with difficulty set to `2`.
+* If `INDEX != n % VALIDATOR_COUNT`, wait for `BLOCK_INTERVAL + rand(VALIDATOR_COUNT) * 0.5` seconds then produce a new block with difficulty set to `1`.
+* If the validator is the attester of the last block, wait for `ATTEST_INTERVAL` blocks then continue this strategy.
+
+`ATTEST_INTERVAL` is used for preventing malicious validators to censors the POA network. When malicious validators are less than `ATTEST_INTERVAL + 1` that at least an honest validator have the chance to submit votes and evict malicious validators.
+
+`ATTEST_INTERVAL` can be set to `VALIDATOR_COUNT / 2` the honest validators could eventually evict malicious validators unless the half of validators are corrupted.
+
+## validator list
+
+Validator list can be represented as a list of pubkey hash.
+
+``` txt
+pubkey_hash_1 | pubkey_hash_2 | pubkey_hash_3 ...
+```
+
+We can use an `M of N` multisig lock to describe the validator list, the `M` is set to `VOTE_LIMIT`, and `N` is `VALIDATORS_COUNT`.
+
+To change the validator list, a validator can collect enough votes(the signatures) and send a tx to spent the old multisig lock and construct a new multisig lock with new pubkey hashes. A validator node can use `type_id` to track this validator list.
+
+The pre-defined [multisig script](https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0021-ckb-address-format/0021-ckb-address-format.md#short-payload-format) is satisfied the requirements, one except is the `multisig script` should be public so other nodes can check new validator list. Validators should make sure the entire `multisig script` is stored to cell data, and only one cell is constructed to represent the validator list.
+
+Notice, the process of collect data is not included in the POA protocol for simplifying, a responsible validator should check the vote tx carefully before signing it.
+
+## POA header
+
+Unfortunately, CKB header is fixed-length, the `nonce` field takes 128 bits, we can't just put 256 bits secp256k1 signature into the header.
+
+For easier implementation, instead change the block header structure, we put an extra POA context concatenated after cellbase transaction's first witness. To verify a header attestation, we need both the header and the cellbase transaction.
+
+The structure of `POAContext`:
+
+``` txt
+table POAContext {
+    signature:              Byte65,
+    transactions_count:     Uint32,
+    raw_transactions_root:  Byte32, // witness transactions root
+    merkle_proof:           Byte32Vec, // merkle proof of cellbase and voting txs
+    voting_txs:             TransactionVec,
+}
+```
+
+The first field `signature` is a secp256k1 signature signed by a validator.
+
+The signature message is supposed to digest the whole block except the signature itself.
+
+Because the signature is put into the cellbase transaction's witness, and the cellbase itself is digested by the `transaction_root` in the header. If we change the cellbase transaction the `transaction_root` and block hash will also be changed.
+
+We use merkle proof to prove the only changes of the header hash is caused by the `signature` field.
+
+* `merkle_proof` - a merkle proof to prove that cellbase transaction belongs to a `witness_transactions_root`.
+* `raw_transactions_root` - raw transactions root of current block.
+* `transactions_count` - number of transactions.
+
+A node does the following steps to verify the POA header:
+
+1. verify merkle proof is correct.
+    1. calculate `witness_transactions_root` from cellbase and merkle proof `merkle_proof.root(cellbase_hash, transactions_count)`
+    2. calculate `transactions_root = merkle_root([witness_transactions_root, raw_transactions_root])`
+    3. check `transactions_root` equals to `header.transactions_root`
+2. zerorize `signature` field of POAContext in cellbase transaction.
+    1. extract `POAContext` from cellbase transaction witness
+    2. set `signature` field to "0x000...0000(32bytes)"
+    3. set `POAContext` back to cellbase transaction witness
+3. calculate signing message from zerorized cellbase transaction.
+    1. calculate `transactions_root` with zerorized cellbase transaction
+    2. replace header's old `transactions_root` then calculate `blake2b_256(header)` as signature message
+4. recovery the pubkey from `signature` then check the pubkey hash is belongs to a validator.
+
+Because we have a dynamic validators group, To keep enough information to verify a header, we also put the voting transactions into `voting_txs` field, a validator can verify header and get newest validator groups without download the whole blocks
+
+## changes on CKB
+
+(TODO)
+
+## references
+
+1. [Rinkeby proposal](https://github.com/ethereum/EIPs/issues/225)

--- a/rfcs/0000-poa-testnet/0000-poa-testnet.md
+++ b/rfcs/0000-poa-testnet/0000-poa-testnet.md
@@ -14,7 +14,7 @@ Created: <TBD>
 The original intention of aggron testnet is to provide a development-friendly testnet,
  allow develops to deploy and test contracts, it's supposed to be similar to mainnet and provide stable services.
 
-However, the mining power on aggron is very unstable[chars](https://explorer.nervos.org/aggron/charts), Obviously for a reasonable miner there is no incitive to mine the testnet coins, and any new miner or mining pool join the testnet will speedup the block produces time temporally, then they leave, the testnet become extremely slow, the avg block time becomes few minutes or even longer.
+However, the mining power on aggron is very unstable (shown in [chars](https://explorer.nervos.org/aggron/charts)), obviously for a reasonable miner there is no incitive to mine the testnet coins, and any new miner or mining pool join the testnet will speedup the block produces time temporally, then they leave, the testnet become extremely slow, the avg block time becomes few minutes or even longer.
 
 A POW blockchain only works when the miner has economic incentives. So we propose a new POA consensus testnet to serve contract development purposes.
 

--- a/rfcs/0000-poa-testnet/0000-poa-testnet.md
+++ b/rfcs/0000-poa-testnet/0000-poa-testnet.md
@@ -13,9 +13,9 @@ Created: 2019-12-9
 
 The original intention of the aggron testnet is to provide a stable environment for contract development.
 
-However, the mining power on aggron is volatile (shown in [charts](https://explorer.nervos.org/aggron/charts)), since a rational miner has no incentive to mine the testnet coins continuously. If any new miner or mining pool joins, the mining difficulty rises fast. Once they leave, the testnet block produce becomes extremely slow due to a sudden drop of hashrate, and the average block time would require minutes or even longer.
+However, the mining power on aggron is volatile (shown in [charts](https://explorer.nervos.org/aggron/charts)), since a rational miner has no incentive to mine the testnet coins continuously. If any new miner or mining pool joins, the mining difficulty rises fast. Once they leave, new block generation becomes extremely slow due to a sudden drop of hashrate, and the average block time would require minutes or even longer.
 
-A POW blockchain only works when the miner has economic incentives, it's not adapted for the testnet, so we propose a new POA consensus testnet to serve the contract development purpose.
+A POW blockchain only works when the miner has economic incentives that conflict with the nature of the testnet, so we propose a new POA consensus testnet to serve the contract development purpose.
 
 We expect the new POA testnet to be long term stable, and the testnet should be just like the mainnet without using POW. A contract developer should feel no difference when developing on POA testnet and mainnet.
 
@@ -32,7 +32,7 @@ We define the following variables:
 * `VALIDATOR_COUNT` - Number of current validators, this value changed due to new validators join or old validator leaves.
 * `ATTEST_INTERVAL` - A validator cannot attest two blocks within `ATTEST_INTERVAL` number. For example, a validator who attest block (6) must wait for at least `ATTEST_INTERVAL` blocks to do next attest: block (6 + `ATTEST_INTERVAL` + 1). Notice when the `VALIDATOR_COUNT` <= `ATTEST_INTERVAL`, the POA testnet will stuck forever due to no validators can attest a new block.
 * `BLOCK_INTERVAL` - the interval of blocks, set to 8 seconds.
-* `VOTE_LIMIT` - The least votes to make a new validator join or to evict an old validator, should be at least `VALIDATOR_COUNT / 2 + 1`.
+* `VOTE_THRESHOLD` - The least votes to make a new validator join or to evict an old validator, should be at least `VALIDATOR_COUNT / 2 + 1`.
 
 ### attest a new block
 
@@ -61,7 +61,7 @@ The first malicious validator must wait for `ATTEST_INTERVAL + 1` blocks to prod
 
 ### validator list and on-chain governance
 
-As previously described, the POA testnet maintained by a group of validators. We have a build-in on-chain governance mechanism to allows updating the exists validator list. The on-chain governance mechanism designed to be loose; it allows several validators that greater than `VOTE_LIMIT` to sign a transaction together that updating the exists validators to a list of new validators.
+As previously described, the POA testnet maintained by a group of validators. We have a build-in on-chain governance mechanism to update the exists validator list; it allows several validators that greater than `VOTE_THRESHOLD` to sign a transaction together that updating the exists validators to a list of new validators.
 
 As a natural thought, we can use a CKB cell to store the validator list, and the validator list can represent in a list of pubkey hash.
 
@@ -76,34 +76,33 @@ The pre-defined [multisig script] satisfies our on-chain governance requirements
 So we choose to use a cell to represent the POA validator list. The cell contains the following `multisig script` in its data field, and with a multisig lock to lock the cell, the `multisig script` in data must corresponding to the lock's `multisig script`.
 
 ``` txt
-0 | 0 | VOTE_LIMIT | VALIDATOR_COUNT | blake160(Pubkey1) | blake160(Pubkey2) | ...
+0 | 0 | VOTE_THRESHOLD | VALIDATOR_COUNT | blake160(Pubkey1) | blake160(Pubkey2) | ...
 ```
 
-We use a cell with `M of N` multisig lock to describe the validator list, the`M` set to `VOTE_LIMIT`, and `N` set to `VALIDATORS_COUNT`, we need an extra parameter to represent `ATTEST_INTERVAL`, so the final data is a 4 bytes little-endian number to represent `ATTEST_INTERVAL` plus a `multisig script`:
+We use a cell with `M of N` multisig lock to describe the validator list, the `M` set to `VOTE_THRESHOLD`, and `N` set to `VALIDATORS_COUNT`, we need an extra parameter to represent `ATTEST_INTERVAL`, so the final data is a 4 bytes little-endian number to represent `ATTEST_INTERVAL` plus a `multisig script`:
 
 ``` txt
-ATTEST_INTERVAL(4 bytes little-endian) | 0 | 0 | VOTE_LIMIT | VALIDATOR_COUNT | blake160(Pubkey1) | blake160(Pubkey2) | ...
+ATTEST_INTERVAL(4 bytes little-endian) | 0 | 0 | VOTE_THRESHOLD | VALIDATOR_COUNT | blake160(Pubkey1) | blake160(Pubkey2) | ...
 ```
 
 To change the validator list, anyone that collects enough votes(the signatures) can send a transaction to update the old validator list cell and construct a new validator list cell.
 
-For simplify to track this cell, we assign a `type_id` on it; validators or anyone who wants to verify POA blocks must track this cell to keep validator list fresh.
+To simplify the tracking of this cell, we assign a `type_id` on it; validators or anyone who wants to keep a fresh validator list can track the change of this cell by its `type_id`.
 
-Before sign a vote transaction, validators must make sure the `multisig script`  in the cell is valid and corresponding to the lock, and only one cell constructed to represent the validator list; otherwise, the POA consensus wound broken.
+Before signing a vote transaction, validators must make sure the `multisig script` in the cell is valid and corresponding to the lock, and only one cell constructed to represent the validator list; otherwise, the POA consensus wound broken.
 
-To simplify, the process of collecting votes do not include in the POA protocol.
 
 ### off-chain governance
 
 The main intention of this document is to describe the POA testnet protocol. However, to better explain how the POA testnet validator works, we add this section as a suggestion to the off-chain governance, notice this section is more like a suggestion than a specification.
 
-The intention of on-chain governance and dynamic validators design is to decentralize the POA testnet. Instead of the foundation itself, the community should finally maintain the POA testnet validators.
+The intention of on-chain governance and dynamic validators design is to decentralize the POA testnet. Instead of the foundation, the community should be the maintainer of the POA testnet.
 
-In the initial stage of the POA testnet, there may be just a small group validator that invited by the Nervos foundation. The validators together should governance the testnet and invite more validators from the community. A candidate validator may be a company or organization that influences the community. 
+In the initial stage of the POA testnet, there may be just a small group validator that invited by the Nervos foundation. The validators together should governance the testnet and invite more validators from the community. A candidate validator may be a reputable company or organization in the community. 
 
 A possible way to elect candidate validators: 
 
-The exists validators deploy a permissionless voting DAPP on the mainnet allows any company and organization can register them as a candidate. 
+The exists validators deploy a permissionless voting DAPP on the mainnet allows any company and organization to register as a candidate. 
 Anyone can deposit mainnet coins to vote on the candidates. 
 The POA testnet validators obey the result of the DApp to invites the candidate to become the testnet validator.
 
@@ -111,7 +110,7 @@ Such an election should periodically host.
 
 ## POA header
 
-CKB header encoded in fixed-length, the size of the `nonce` field is 128 bits, we can't put 256 bits secp256k1 signature into the header directly.
+CKB header is length fixed, the size of the `nonce` field is 128 bits, we can't put 256 bits secp256k1 signature into the header directly.
 
 For the ease of implementation, instead of changing the block header structure, we put an extra POA payload `POAContext` in the cellbase transaction's first witness. To verify a header, we need both the header and the cellbase transaction.
 
@@ -154,7 +153,7 @@ A node does the following steps to verify a POA header:
 3. re-comute the block's `transaction_root` and block hash. 
 4. recovery the pubkey, then check the pubkey hash is belongs to a validator.
 
-Now we can verify a POAHeader with fixed validators. However, when validator list updated, the header-first synchronization may couldn't handle it correctly, think the following situation:
+Now we can verify a POAHeader with fixed validators. However, when validator list updated, the header-first synchronization may couldn't handle it correctly, consider the following situation:
 The initial validators list is `[A, B, C, D]`.
 Since block `N`, the validator list updated to `[A, B, D, E]`.
 A header-first synchronization from `N - 1` to `N + 4` wound fails to sync due to the unknown validator `E`.

--- a/rfcs/0000-poa-testnet/0000-poa-testnet.md
+++ b/rfcs/0000-poa-testnet/0000-poa-testnet.md
@@ -32,6 +32,7 @@ We define the following variables:
 * `VALIDATOR_COUNT` - Number of current validators, this value changed due to new validators join or old validator leaves.
 * `ATTEST_INTERVAL` - A validator cannot attest two blocks within `ATTEST_INTERVAL` number. For example, a validator who attest block (6) must wait for at least `ATTEST_INTERVAL` blocks to do next attest: block (6 + `ATTEST_INTERVAL` + 1). Notice when the `VALIDATOR_COUNT` <= `ATTEST_INTERVAL`, the POA testnet will stuck forever due to no validators can attest a new block.
 * `BLOCK_INTERVAL` - the interval of blocks, set to 8 seconds.
+* `BLOCK_TIMEOUT` - timeout for new block generation, set to 10 seconds.
 * `VOTE_THRESHOLD` - The least votes to make a new validator join or to evict an old validator, should be at least `VALIDATOR_COUNT / 2 + 1`.
 
 ### attest a new block
@@ -47,8 +48,8 @@ However, an in-turned attester may fail to produce a block due to network error 
 Validators can use a simple strategy:
 
 1. For block height `n` a validator checks `n % VALIDAROR_COUNT`.
-2. If `INDEX == n % VALIDATOR_COUNT`, which means the validator is in it's turn to attests block `n`. The validator should wait for `BLOCK_INTERVAL` seconds then attests the block `n` with difficulty set to `2`.
-3. If `INDEX != n % VALIDATOR_COUNT`, which means the validator is not in it's turn to attests block `n`. The validator should wait for `BLOCK_INTERVAL + rand(VALIDATOR_COUNT) * 0.5` seconds to wait for another attester to produce a new block. If there are no new block produced during the time, the validator should attest a new block with difficulty set to `1`.
+2. If `INDEX == n % VALIDATOR_COUNT`, which means the validator is in its turn to attests block `n`. The validator should wait for `BLOCK_INTERVAL` seconds then attests the block `n` with difficulty set to `2`.
+3. If `INDEX != n % VALIDATOR_COUNT`, which means the validator is not in its turn to attests block `n`. The validator should wait for `BLOCK_TIMEOUT + rand(VALIDATOR_COUNT) * 0.5` seconds to wait for another attester to produce a new block. If there are no new block produced during the time, the validator should attest a new block with difficulty set to `1`.
 4. If the validator is the attester of the last block, wait for `ATTEST_INTERVAL` blocks then continue this strategy.
 
 Notice the difficulty set to `2` when an in-turn attester produces a block and set to `1` when a not in-turn attester produces a block. This makes the in-turn attester's block total difficulty higher than the not in-turn attester's block; once two validators attest at the same height due to the network error, the other nodes still chooses the higher total difficulty block as the main chain.


### PR DESCRIPTION
Updates:

* 2019-12-19: update off-chain governance
* 2019-12-18: update block attestation and verification

--------------

The Aggron testnet is use POW. Unfortunately, the average block time can be very slow even up to a few minutes due to mining power join and leave, see the peak from the chart https://explorer.nervos.org/aggron/charts.

To provide a stable testnet for development I propose a POA testnet to replace the current Aggron.

* The block time should be very stable, approximate to 8 seconds.
* The POA testnet supposed to be a long term running testnet, the validators of the testnet should be maintained and governance by the community.
* A minority malicious validators can't halt or censorship on POA testnet.

[view file](https://github.com/jjyr/rfcs/blob/poa-testnet/rfcs/0000-poa-testnet/0000-poa-testnet.md)