### PR TITLE
Support type script in CKB address

### DIFF
--- a/rfcs/0021-ckb-address-format/0021-ckb-address-format.md
+++ b/rfcs/0021-ckb-address-format/0021-ckb-address-format.md
@@ -11,11 +11,14 @@ Created: 2019-01-20
 
 ## Abstract
 
-*CKB Address Format* is an application level cell **lock script** display recommendation. The lock script consists of three key parameters, including *code_hash*, *hash_type* and *args*. CKB address packages lock script into a single line, verifiable, and human read friendly format.
+*CKB Address Format* is recommended to handle the encodings for both **lock script** and **type script** in application level. CKB address can package a script into a single line format, which is verifiable and human-readable.
 
 ## Data Structure
 
-### Payload Format Types
+Both **lock script** and **type script** consist of three key properties, including *code_hash*, *hash_type* and *args*. Following the payload formatting rules outlined below, a script data structure can be encoded as a CKB address, which can be parsed for its original script reversely.
+
+### Lock script
+#### Payload Format Types
 
 To generate a CKB address, we firstly encode lock script to bytes array, name *payload*. And secondly, we wrap the payload into final address format.
 
@@ -27,7 +30,7 @@ There are several methods to convert lock script into payload bytes array. We us
 |  0x02       | full version with hash_type = "Data"           |
 |  0x04       | full version with hash_type = "Type"           |
 
-### Short Payload Format
+#### Short Payload Format
 
 Short payload format is a compact format which identifies common used code_hash by 1 byte code_hash_index instead of 32 bytes code_hash.
 
@@ -59,15 +62,41 @@ For example, Alice, Bob, and Cipher collectively control a multisig locked cell.
 0 | 1 | 2 | 3 | Pk_Cipher_h | Pk_Alice_h | Pk_Bob_h
 ```
 
-### Full Payload Format
+#### Full Payload Format
 
-Full payload format directly encodes all data field of lock script.
+Full payload format directly encodes all data fields of lock script.
 
 ```c
 payload = 0x02/0x04 | code_hash | args
 ```
 
 The first byte identifies the lock script's hash_type, 0x02 for "Data", 0x04 for "Type". 
+
+### Type script
+#### Payload Format Types
+
+The rule of CKB address generation for type script is almost the same as lock script. The encoding only needs to take care of the full address formatting, as `Short Payload Format` is not applicable for type script at the moment.
+
+In the encoding rule, similarly we use 1 byte to identify the payload format but based from `0x80`. Since both lock script and type script have the same enum values for `hash_type`, which are "Data" and "Type", it is intended for the last hex character to reflect the same `hash_type` mapping for type script as lock script does.
+
+| format type |                   description                  |
+|:-----------:|------------------------------------------------|
+|  0x82       | full version with hash_type = "Data"           |
+|  0x84       | full version with hash_type = "Type"           |
+
+#### Full Payload Format
+
+Full payload format encodes all data fields of type script.
+
+```c
+payload = 0x82/0x84 | code_hash | args
+```
+
+### Format Types Allocation
+
+As detailed in the `Payload Format Types` sections, so far the format type flags `0x0#` are reserved for lock script, while the flags `0x8#` are for type script. This allocation rule of format types can be referenced to derive either a lock script or type script from a CKB address. 
+
+For example, if the byte value for format type is smaller than `0x80`, then it should follow the format rule of lock script to decode the payload. Otherwise, the CKB address represents a type script.
 
 ## Wrap to Address
 

--- a/rfcs/0021-ckb-address-format/0021-ckb-address-format.md
+++ b/rfcs/0021-ckb-address-format/0021-ckb-address-format.md
@@ -11,11 +11,11 @@ Created: 2019-01-20
 
 ## Abstract
 
-*CKB Address Format* is recommended to handle the encodings for both **lock script** and **type script** in application level. CKB address can package a script into a single line format, which is verifiable and human-readable.
+*CKB Address Format* is recommended to handle the encodings for both **lock script** and **type script** in the application level. CKB address can package a script into a single line format, which is verifiable and human-readable.
 
 ## Data Structure
 
-Both **lock script** and **type script** consist of three key properties, including *code_hash*, *hash_type* and *args*. Following the payload formatting rules outlined below, a script data structure can be encoded as a CKB address, which can be parsed for its original script reversely.
+Both **lock script** and **type script** consist of three key properties, including *code_hash*, *hash_type* and *args*. Following the payload formatting rules outlined below, a script data structure can be encoded as a CKB address. Likewise, a CKB address can be parsed for its original script.
 
 ### Lock script
 #### Payload Format Types
@@ -32,7 +32,7 @@ There are several methods to convert lock script into payload bytes array. We us
 
 #### Short Payload Format
 
-Short payload format is a compact format which identifies common used code_hash by 1 byte code_hash_index instead of 32 bytes code_hash.
+Short payload format is a compact format which identifies commonly used code_hash by 1 byte code_hash_index instead of 32 bytes code_hash.
 
 ```c
 payload = 0x01 | code_hash_index | args
@@ -75,9 +75,9 @@ The first byte identifies the lock script's hash_type, 0x02 for "Data", 0x04 for
 ### Type script
 #### Payload Format Types
 
-The rule of CKB address generation for type script is almost the same as lock script. The encoding only needs to take care of the full address formatting, as `Short Payload Format` is not applicable for type script at the moment.
+The rule of CKB address generation for type script is almost the same as the lock script. The encoding only needs to take care of the full address formatting, as `Short Payload Format` is not applicable for type script.
 
-In the encoding rule, similarly we use 1 byte to identify the payload format but based from `0x80`. Since both lock script and type script have the same enum values for `hash_type`, which are "Data" and "Type", it is intended for the last hex character to reflect the same `hash_type` mapping for type script as lock script does.
+Similarly, in the encoding rule, we use 1 byte to identify the payload format but starting from `0x80`. Since both lock script and type script have the same enum values for `hash_type`, which are **Data** and **Type**, it is intended for the last hex character to reflect the same `hash_type` mapping for type script as lock script does.
 
 | format type |                   description                  |
 |:-----------:|------------------------------------------------|
@@ -94,9 +94,9 @@ payload = 0x82/0x84 | code_hash | args
 
 ### Format Types Allocation
 
-As detailed in the `Payload Format Types` sections, so far the format type flags `0x0#` are reserved for lock script, while the flags `0x8#` are for type script. This allocation rule of format types can be referenced to derive either a lock script or type script from a CKB address. 
+As detailed in the `Payload Format Types` sections, the format type flags `0x0#` are reserved for lock script, while the flags `0x8#` are for type script. The applications can reference this allocation rule to derive either a lock script or type script from a CKB address. 
 
-For example, if the byte value for format type is smaller than `0x80`, then it should follow the format rule of lock script to decode the payload. Otherwise, the CKB address represents a type script.
+For example, if the byte value for format type is smaller than `0x80`, it should follow the format rule of lock script to decode the payload. Otherwise, the CKB address represents a type script.
 
 ## Wrap to Address
 


### PR DESCRIPTION
This PR is a proposal to have current CKB address RFC support the encoding of type script in addition to lock script. 

## Reasoning
In some use cases, such as creating an asset account on Neuron, where the metadata of a type script is partially hardcoded while the users need to pass in the `args` to identify an sUDT.

The example below is the hardcoded part in Neuron to handle sUDT transactions or related queries via Lumos indexer(ckb-indexer):

```
SUDT_SCRIPT_CODEHASH=0x48dbf59b4c7ee1547238021b4869bceedf4eea6b43772e5d66ef8865b6ae7212
SUDT_SCRIPT_HASHTYPE=data
SUDT_DEP_TXHASH=0xc1b2ae129fad7465aaa9acc9785f842ba3e6e8b8051d899defa89f5508a77958
SUDT_DEP_INDEX=0
SUDT_DEP_TYPE=code
```

When making queries via Lumos indexer, it only needs to specify the type script (`CODEHASH`, `HASHTYPE`, `ARGS`). Once the CKB address support encoding of type script, the applications won't need to hardcode the (`CODEHASH`, `HASHTYPE`) anymore, as the users can specify in application-level which type script they want to query with via a CKB address.

## Further thoughts
However, in order to transact with the sUDT, it will need the other metadata (`DEP_TXHASH`, `DEP_INDEX`, `DEP_TYPE`) to locate the **seed cell** holding the code represented by a type script. This applies to the case of anyone-can-pay lock script as well.

It is straightforward to update the existing CKB address RFC to support the encoding of type script, since the encoding rule is almost the same as lock script. For the `cell dependency` part, it might be worthwhile to consider if CKB address should be upgraded to support the encoding of `cell dependency` metadata. 

The benefit of doing so is that the applications won't need to hardcode any metadata for the users to transact with any UDT that can be specified with a single CKB address. Additionally, a CKB address can be referenced to locate a seed cell, which we don't seem to have a convenient way to locate at the moment. 

The downside is that it would make the CKB address string longer and handle the additional data points as it comes with the additional `cell dependency` information.

Therefore, welcome any comments and see if it makes sense to locate the **seed cell** using a CKB address.