### PR TITLE
[DRAFT] Cell mapper

### DIFF
--- a/rfcs/0025-cell-mapper/0025-cell-mapper.md
+++ b/rfcs/0025-cell-mapper/0025-cell-mapper.md
@@ -1,0 +1,26 @@
+---
+Number: "0025"
+Category: Standards Track
+Status: Proposal
+Author: Katat Choi
+Organization: Nervos Foundation
+Created: 2020-7-30
+---
+
+# CKB Cell Mapper
+
+## Abstract
+
+## Motivation
+
+## Specification
+
+### Cell Address Encoding
+
+### Collect Script Metadata 
+#### UDT type script
+#### ACP lock script
+
+## Example
+### Sample code
+### Demo repository


### PR DESCRIPTION
This proposal is an alternative solution to the script usability issue that [my previous PR](https://github.com/nervosnetwork/rfcs/pull/199) was trying to resolve, as a result of the discussions with the core team members. 

The idea is to come up with a standard to reference an outpoint to locate a cell in a transaction, which has the native references to locate all the necessary metadata of a script. Thus, the new approach should be able to resolve the outstanding issues mentioned in my previous PR. With the ability to load script metadata on the fly, the applications would have more flexibility in the support of custom contract scripts in the long run.

For now, I name this RFC as **Cell Mapper**, because it would serve as a map from a cell to the metadata of a script. The alternative name could be **Script Mapper**. I am open-minded to any other suggestions in the naming.

As outlined below, the mapping process will involve two steps:
1. Encodings between an outpoint data structure and a cell address string.
2. A rule to fetch the script metadata relating to a cell.

It will include a CLI demo for everyone to play around the decode/encode of cell address, and query on the script metadata.

Please feel free to let me know if any comments.