### PR TITLE
RFC36: remove header deps immature rule

### DIFF
--- a/rfcs/0009-vm-syscalls/0009-vm-syscalls.md
+++ b/rfcs/0009-vm-syscalls/0009-vm-syscalls.md
@@ -445,7 +445,11 @@ In case of errors, `addr` and `index` will not contain meaningful data to use.
 #### Loading Header Immature Rule
 [loading header immature Rule]: #loading-header-immature-error
 
-**Attention** that the script can only load the header of a block which is 4 epochs ago, otherwise the header is immature and the transaction must wait. For example, if the block is the first block in epoch 4, a transaction loading its header can only be included in the first block of epoch 8 and later blocks.
+Attention that all the blocks referenced in header deps must be 4 epochs ago, otherwise the header is immature and the transaction must wait. For example, if the block is the first block in epoch 4, a transaction with its header as a header dep can only be included in the first block of epoch 8 and later blocks.
+
+This rule will be removed since ckb2021 as proposed in [RFC36].
+
+[RFC36]: ../0036-remove-header-deps-immature-rule/0036-remove-header-deps-immature-rule.md
 
 ### Load Header By Field
 [load header by field]: #load-header-by-field

--- a/rfcs/0036-remove-header-deps-immature-rule/0036-remove-header-deps-immature-rule.md
+++ b/rfcs/0036-remove-header-deps-immature-rule/0036-remove-header-deps-immature-rule.md
@@ -11,7 +11,9 @@ Created: 2021-02-07
 
 ## Abstract
 
-This document proposes removing the loading header immature rule.
+This document proposes removing the *[Loading Header Immature Rule]*.
+
+[Loading Header Immature Rule]: ../0009-vm-syscalls/0009-vm-syscalls.md#loading-header-immature-error
 
 In the consensus ckb2019, the header dep must reference the block which is 4 epochs ago. After this RFC is activated, the transaction can use any existing blocks in the chain as the header dep.
 
@@ -19,9 +21,9 @@ In the consensus ckb2019, the header dep must reference the block which is 4 epo
 
 Header dep is a useful feature for dApps developers because script can use it to read the header of a block in the chain, or verify that an input cell or dep cell is in a specific block in the chain.
 
-The immature rule prevents the usage of header deps in many scenarios because the script must reference the block about 16 hours ago.
+The *Loading Header Immature Rule* prevents the usage of header deps in many scenarios because the script must reference the block about 16 hours ago.
 
-The intention of the immature rule is like the cellbase immature rule, a transaction with header deps and all its descendants can be invalidated after a chain reorganization [^1], because the referenced block may be rollbacked.
+The intention of the immature rule is like the cellbase immature rule, a transaction with header deps and all its descendants can be invalidated after a chain reorganization [^1], because the referenced block may be rolled back.
 
 [^1]: Chain reorganization happens when the node found a better chain with more accumulated proved work and it has to rollback blocks to switch to the new chain.
 

--- a/rfcs/0036-remove-header-deps-immature-rule/0036-remove-header-deps-immature-rule.md
+++ b/rfcs/0036-remove-header-deps-immature-rule/0036-remove-header-deps-immature-rule.md
@@ -23,7 +23,7 @@ Header dep is a useful feature for dApps developers because script can use it to
 
 The *Loading Header Immature Rule* prevents the usage of header deps in many scenarios because the script must reference the block about 16 hours ago.
 
-The intention of the immature rule is like the cellbase immature rule, a transaction with header deps and all its descendants can be invalidated after a chain reorganization [^1], because the referenced block may be rolled back.
+The intention of the immature rule is like the cellbase immature rule, a transaction with header deps and all its descendants can be invalidated after a chain reorganization [^1], because the referenced block may be rolled back. Removing the rule lets dApps developers to trade off between responsive header reference and reliable transaction finality.
 
 [^1]: Chain reorganization happens when the node found a better chain with more accumulated proved work and it has to rollback blocks to switch to the new chain.
 

--- a/rfcs/0036-remove-header-deps-immature-rule/0036-remove-header-deps-immature-rule.md
+++ b/rfcs/0036-remove-header-deps-immature-rule/0036-remove-header-deps-immature-rule.md
@@ -19,16 +19,16 @@ In the consensus ckb2019, the header dep must reference the block which is 4 epo
 
 ## Motivation
 
-Header dep is a useful feature for dApps developers because script can use it to read the header of a block in the chain, or verify that an input cell or dep cell is in a specific block in the chain.
+Header dep is a useful feature for dApps developers because the script can read the block's header in the chain or verify that an input cell or dep cell is in a specific block in the chain.
 
 The *Loading Header Immature Rule* prevents the usage of header deps in many scenarios because the script must reference the block about 16 hours ago.
 
-The intention of the immature rule is like the cellbase immature rule, a transaction with header deps and all its descendants can be invalidated after a chain reorganization [^1], because the referenced block may be rolled back. Removing the rule lets dApps developers to trade off between responsive header reference and reliable transaction finality.
+The intention of the immature rule is like the cellbase immature rule. A transaction and all its descendants may be invalidated after a chain reorganization [^1], because its header deps referred to stale or orphan blocks. Removing the rule lets dApps developers trade-off between responsive header reference and reliable transaction finality.
 
 [^1]: Chain reorganization happens when the node found a better chain with more accumulated proved work and it has to rollback blocks to switch to the new chain.
 
 ## Specification
 
-This RFC must be activated via a hard fork. After activation, the consensus no longer verifies that the referenced block in the header deps has been mined 4 epochs ago.
+This RFC must be activated via a hard fork. After activation, the consensus no longer verifies that the referenced block in the header deps is mined 4 epochs ago.
 
-The transaction producers can choose to postpone the transaction submission when it has a header dep which has been mined recently. It's recommended to wait at least 4 epochs but the app can choose the best value in its scenario, like the transaction confirmation period.
+The transaction producers can choose to postpone the transaction submission when it has a header dep that has been mined recently. It suggests waiting for at least 4 epochs, but the app can choose the best value in its scenario, like the transaction confirmation period.

--- a/rfcs/0036-remove-header-deps-immature-rule/0036-remove-header-deps-immature-rule.md
+++ b/rfcs/0036-remove-header-deps-immature-rule/0036-remove-header-deps-immature-rule.md
@@ -1,1 +1,32 @@
-In review, see <https://github.com/nervosnetwork/rfcs/pull/240>
+---
+Number: "0036"
+Category: Consensus (Hard Fork)
+Status: Draft
+Author: Ian Yang
+Organization: Nervos Foundation
+Created: 2021-02-07
+---
+
+# Remove Header Deps Immature Rule
+
+## Abstract
+
+This document proposes removing the loading header immature rule.
+
+In the consensus ckb2019, the header dep must reference the block which is 4 epochs ago. After this RFC is activated, the transaction can use any existing blocks in the chain as the header dep.
+
+## Motivation
+
+Header dep is a useful feature for dApps developers because script can use it to read the header of a block in the chain, or verify that an input cell or dep cell is in a specific block in the chain.
+
+The immature rule prevents the usage of header deps in many scenarios because the script must reference the block about 16 hours ago.
+
+The intention of the immature rule is like the cellbase immature rule, a transaction with header deps and all its descendants can be invalidated after a chain reorganization [^1], because the referenced block may be rollbacked.
+
+[^1]: Chain reorganization happens when the node found a better chain with more accumulated proved work and it has to rollback blocks to switch to the new chain.
+
+## Specification
+
+This RFC must be activated via a hard fork. After activation, the consensus no longer verifies that the referenced block in the header deps has been mined 4 epochs ago.
+
+The transaction producers can choose to postpone the transaction submission when it has a header dep which has been mined recently. It's recommended to wait at least 4 epochs but the app can choose the best value in its scenario, like the transaction confirmation period.


### PR DESCRIPTION
This document proposes removeing the loading header immature rule.

In the consensus ckb2019, the header dep must reference the block which is 4 epochs ago. After this RFC is activated, the transaction can use any existing blocks in the chain as the header dep.