### PR TITLE
RFC24: add cheque info

### DIFF
--- a/rfcs/0024-ckb-system-script-list/0024-ckb-system-script-list.md
+++ b/rfcs/0024-ckb-system-script-list/0024-ckb-system-script-list.md
@@ -247,6 +247,76 @@ and the `out_point` of `anyone_can_pay` is
 }
 ```
 
+### cheque
+
+[cheque](https://talk.nervos.org/t/sudt-cheque-deposit-design-and-implementation/5209) ([Source Code](https://github.com/nervosnetwork/ckb-cheque-script/tree/4ca3e62ae39c32cfcc061905515a2856cad03fd8)) allows a sender to temporarily provide cell capacity in asset transfer.
+
+cheque script is for **lock script**:
+
+- Lina
+
+| parameter   | value                                                                |
+| ----------- | -------------------------------------------------------------------- |
+| `code_hash` | `0xe4d4ecc6e5f9a059bf2f7a82cca292083aebc0c421566a52484fe2ec51a9fb0c` |
+| `hash_type` | `type`                                                               |
+| `tx_hash`   | `0x04632cc459459cf5c9d384b43dee3e36f542a464bdd4127be7d6618ac6f8d268` |
+| `index`     | `0x0`                                                                |
+| `dep_type`  | `dep_group`                                                          |
+
+**Note:**
+
+The `dep_type` of `cheque` in Lina is `dep_group` means that the content of this dep cell contains two cell deps which are `secp256k1_data` and `cheque` whose `dep_type` are `code`.
+
+The `out_point` of `secp256k1_data` is
+
+```
+{
+  tx_hash: 0xe2fb199810d49a4d8beec56718ba2593b665db9d52299a0f9e6e75416d73ff5c,
+  index: 0x3
+}
+```
+
+and the `out_point` of `cheque` whose `dep_type` is `code` is
+
+```
+{
+  tx_hash: 0x0a34aeea122d9795e06e185746a92e88bca0ad41b0e5842a960e5fd1d43760a6,
+  index: 0x0
+}
+```
+
+- Aggron
+
+| parameter   | value                                                                |
+| ----------- | -------------------------------------------------------------------- |
+| `code_hash` | `0x60d5f39efce409c587cb9ea359cefdead650ca128f0bd9cb3855348f98c70d5b` |
+| `hash_type` | `type`                                                               |
+| `tx_hash`   | `0x7f96858be0a9d584b4a9ea190e0420835156a6010a5fde15ffcdc9d9c721ccab` |
+| `index`     | `0x0`                                                                |
+| `dep_type`  | `dep_group`                                                          |
+
+**Note:**
+
+The `dep_type` of `cheque` in Aggron is `dep_group` means that the content of this dep cell contains two cell deps which are `secp256k1_data` and `cheque` whose `dep_type` are `code`.
+
+The `out_point` of `secp256k1_data` is
+
+```
+{
+  tx_hash: 0x8f8c79eb6671709633fe6a46de93c0fedc9c1b8a6527a18d3983879542635c9f,
+  index: 0x3
+}
+```
+
+and the `out_point` of `cheque` is
+
+```
+{
+  tx_hash: 0x1b16769dc508c8349803fe65558f49aa8cf04ca495fbead42513e69e46608b6c,
+  index: 0x0
+}
+```
+
 ## Types
 
 ### Nervos DAO


### PR DESCRIPTION
You can send and claim a cheque cell in the Lina by [mercury](https://github.com/nervosnetwork/mercury) with mainnet configuration with the rightful cheque settings written in this RFC.

A theoretical way to verify:
1. The code_hash of cheque script is `0x00000000000000000000000000000000000000000000000000545950455f4944`. See the cheque deploy transaction for [mainnet](https://explorer.nervos.org/transaction/0x0a34aeea122d9795e06e185746a92e88bca0ad41b0e5842a960e5fd1d43760a6) and [testnet](https://explorer.nervos.org/aggron/transaction/0x1b16769dc508c8349803fe65558f49aa8cf04ca495fbead42513e69e46608b6c). The deploy info is also written in this PR.
So, the binary code of cheque is consistent between mainnet and testnet.
2. The data of dep_group cell is completely obeying the dep group rules.
3. We have fully tested the cheque deploying ones on the testnet by mercury. An [example](https://explorer.nervos.org/aggron/transaction/0xed711c1354609792e9db66ce23653d07d00fb5d5c17e892b834025c53b76f227) for create cheque cell. An [example](https://explorer.nervos.org/aggron/transaction/0xe665735a28cbaefa501924f489e3464c145b7885fdfb709ef76b56e2620329ad) for claim cheque cell. 
So, according to theoretical derivation, we can make sure the cheque dep_group cell in mainnet can work.

A practical way to verify:  Use ckb-sdk v0.43.1 or above to successfully create a cheque cell.
1. Get some CKB and sUDT for test. CKB for test should above 305.
2. Set mainnet mercury URL in ckb-sdk, [java](https://github.com/nervosnetwork/ckb-sdk-java/blob/455f866c6faf5f63c781e74edefac5f7426a4019/ckb-mercury-sdk/src/test/java/mercury/constant/MercuryApiFactory.java#L8) or [go](https://github.com/nervosnetwork/ckb-sdk-go/blob/113ffa36146b34f6c294633a41ed961f0aaba1d7/mercury/example/constant/mercury_api_factory.go#L7) . We have deployed a public server here (https://mercury-mainnet.ckbapp.dev/ ) for mainnet mercury, so you can save much time for syning data. 
3. Run a test to create a cheque cell. Test code in [java](https://github.com/nervosnetwork/ckb-sdk-java/blob/455f866c6faf5f63c781e74edefac5f7426a4019/ckb-mercury-sdk/src/test/java/mercury/ActionTest.java#L81) or [go](https://github.com/nervosnetwork/ckb-sdk-go/blob/b7b9eff4f48fb2f3020cb31c630eea17cbc77e81/mercury/example/action_example.go#L53) .  

