### PR TITLE
Finalize 0001 and 0002

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ Nervos RFCs should follow the keyword conventions defined in [RFC 2119](https://
 
 The maintainers of RFCs and the community will review the PR, and you can update the RFC according to comments left in PR. When the RFC is ready and has enough supports, it will be accepted and merged into this repository.
 
-An Informational RFC will be in Draft status once merged and published. It can be made Final by author at any time, or by RFC maintainers if there's no updates to the draft in 12 months.
+An Informational RFC will be in `Draft` status once merged and published. It can be made `Final` by author at any time, or by RFC maintainers if there's no updates to the draft in 12 months.
 
 ### 4. (Standards Track) Propose Your Standard
 
 A Standards Track RFC can be in 1 of 3 statuses:
 
-1. Proposal (Default)
-2. Standard
-3. Obsolete
+1. `Proposal` (Default)
+2. `Standard`
+3. `Obsolete`
 
-A Standards Track RFC will be in **Proposal** status intially, it can always be updated and improved by PRs. When you believe it's rigorous and mature enough after more discussions, you should create a PR to propose making it a **Standard**.
+A Standards Track RFC will be in `Proposal` status intially, it can always be updated and improved by PRs. When you believe it's rigorous and mature enough after more discussions, you should create a PR to propose making it a `Standard`.
 
 The maintainers of RFCs will review the proposal, ask if there's any objections, and discuss about the PR. The PR will be accepted or closed based on **rough consensus** in this early stage.
 

--- a/rfcs/0001-positioning/0001-positioning.md
+++ b/rfcs/0001-positioning/0001-positioning.md
@@ -1,7 +1,7 @@
 ---
 Number: "0001"
 Category: Informational
-Status: Draft
+Status: Final
 Author: The Nervos Team
 Organization: Nervos Foundation
 Created: 2019-09-12

--- a/rfcs/0002-ckb/0002-ckb.md
+++ b/rfcs/0002-ckb/0002-ckb.md
@@ -1,7 +1,7 @@
 ---
 Number: "0002"
 Category: Informational
-Status: Draft
+Status: Final
 Author: Jan Xie
 Organization: Nervos Foundation
 Created: 2018-01-02


### PR DESCRIPTION
RFC 0002 is submitted on 2018-01-02, RFC 0001 is submitted on 2019-09-12. Almost 4 years ago we envisioned a crypto economy running on a layered network: layer 1 for decentralization and security, layer 2 for scalability; layer 1 for assets, layer 2 for applications; layer 1 for verification, layer 2 for computation. These ideas and principles were minority's then but widely accepted today. They stand the test of time.

RFC 0001 and 0002 are left unchanged for quite a long time. As Lina turns 2yo and CKB's first hardfork is on the horizon, I propose to make them final.