### PR TITLE
chore: update discord invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nervos Network RFCs
 
-[![Discord](https://img.shields.io/badge/chat-on%20Discord-7289DA.svg)](https://discord.gg/dBPuQ3qnXS)
+[![Discord](https://img.shields.io/badge/chat-on%20Discord-7289DA.svg)](https://discord.com/invite/nervos)
 
 This repository contains proposals, standards and documentations related to Nervos Network.
 


### PR DESCRIPTION
Replace the revoked link with the permanent customization link.