### PR TITLE
format(rfc39): split references into paragraphs.

### DIFF
--- a/rfcs/0039-cheque/0039-cheque.md
+++ b/rfcs/0039-cheque/0039-cheque.md
@@ -374,4 +374,5 @@ A draft of this specification was previously released, reviewed, and discussed i
 ## References
 
 [1] SUDT Cheque Deposit Design and Implementation, https://talk.nervos.org/t/sudt-Cheque-deposit-design-and-implementation/5209
+
 [2] Cheque Script Source Code, https://github.com/nervosnetwork/ckb-Cheque-script/tree/4ca3e62ae39c32cfcc061905515a2856cad03fd8


### PR DESCRIPTION
GitHub does not insert `<br>` on line breaks.

There are two ways to address this issue:

- Insert empty line to create paragraphs.
- Add two trailing white spaces to insert `<br>`.

This PR adopts the first solution because trailing white spaces are invisible by default in most editors.