### PR TITLE
fix(0044): a stupid design mistake in light client protocol

### DIFF
--- a/rfcs/0044-ckb-light-client/0044-ckb-light-client.md
+++ b/rfcs/0044-ckb-light-client/0044-ckb-light-client.md
@@ -137,7 +137,7 @@ index of leaves in that MMR.
 Each MMR node is defined as follows:
 
 - `children_hash`
-  - For a leaf node, it's an empty hash (`0x0000...0000`).
+  - For a leaf node, it's its header hash.
   - For a non-leaf node, it's the hash of the serialized data that
     concatenate its two children nodes' hashes.
     A node's hash is the hash of its serialized data.


### PR DESCRIPTION
Needless to explain too much; it's a mistake, obviously.

Docs and codes related to it are written in February; and every time when I updated the docs and codes, I didn't notice that mistake, until last night.