### PR TITLE
chore: replace the action to setup Ruby

### DIFF
--- a/.github/workflows/pr-summary.yaml
+++ b/.github/workflows/pr-summary.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
 


### PR DESCRIPTION
```
Run actions/setup-ruby@v1
------------------------
NOTE: This action is deprecated and is no longer maintained.
Please, migrate to https://github.com/ruby/setup-ruby, which is being actively maintained.
------------------------
Error: Version 2.7 not found
```