### PR TITLE
fix: typos in 0017-tx-valid-since.md

### DIFF
--- a/rfcs/0017-tx-valid-since/0017-tx-valid-since.md
+++ b/rfcs/0017-tx-valid-since/0017-tx-valid-since.md
@@ -34,7 +34,7 @@ The relative flag must be set to either `absolute` or `relative` with the specif
 
 When `absolute` is specified, the threshold value is set to the specified `since` value, which is interpreted by the metric selected.
 
-When `relative` is specified, the threshold value is calculated by retrieving the base value from the commitment block and and adding the `since` value. The base value is the block number, epoch number, or timestamp depending on the metric selected. The commitment block is the block in which the input was committed.
+When `relative` is specified, the threshold value is calculated by retrieving the base value from the commitment block and adding the `since` value. The base value is the block number, epoch number, or timestamp depending on the metric selected. The commitment block is the block in which the input was committed.
 
 After the threshold value and target value have been calculated they can be compared. The precondition is fulfilled only if the target value is equal to or greater than the threshold value.
 


### PR DESCRIPTION
Remove duplicates `and`