### PR TITLE
Remove the A extension from the ckb-vm 2023 hardfork description file

### DIFF
--- a/rfcs/0051-ckb2023/0051-ckb2023.md
+++ b/rfcs/0051-ckb2023/0051-ckb2023.md
@@ -30,7 +30,7 @@ Since CKB2023, there will be multiple VM versions available. [RFC32] introduces 
 
 CKB VM v2 bring the following features:
 
-* New syscalls Spawn, Get Memory Limit, Set Content will be added. The syscall Spawn is the core part of this update. The Spawn and the latter two syscalls: Get Memory Limit and Set Content together, implement a way to call another CKB Script in a CKB Script. Unlike the Exec syscall, Spawn saves the execution context of the current script, like posix_spawn, the parent script blocks until the child script ends.
+* New syscalls Spawn and the I/O interface it uses will be added. The syscall Spawn is the core part of this update, it implement a way to call another CKB Script in a CKB Script. Unlike the Exec syscall, Spawn saves the execution context of the current script, like posix_spawn, the parent script blocks until the child script ends.
 * Introduce more [macro-op fusion](https://en.wikichip.org/wiki/macro-operation_fusion) to reduce cycles consumption of scripts.
 
 

--- a/rfcs/0051-ckb2023/0051-ckb2023.md
+++ b/rfcs/0051-ckb2023/0051-ckb2023.md
@@ -11,7 +11,7 @@ Created: 2023-04-17
 The current edition of CKB consensus rules is CKB2021. CKB2023 refers to the new edition of CKB consensus rules after its second hardfork, The purpose of a hard fork is to upgrade and update the rules encoded in the network. The changes are not backward compatible. This document outlines the changes in this upgrade.
 
 ## What's in CKB2023
-CKB2023 will bring significant changes to the consensus rules, these changes include the removal of the reservation rule on version field in the block header, the introduction of a new version of the virtual machine (VM) with new syscalls and standard extensions, and the optimization of performance with new mops. This RFC provides a detailed overview of these changes.
+CKB2023 will bring significant changes to the consensus rules, these changes include the removal of the reservation rule on version field in the block header, the introduction of a new version of the virtual machine (VM) with new syscalls, and the optimization of performance with new mops. This RFC provides a detailed overview of these changes.
 
 
 ### CKB VM v2
@@ -31,7 +31,6 @@ Since CKB2023, there will be multiple VM versions available. [RFC32] introduces 
 CKB VM v2 bring the following features:
 
 * New syscalls Spawn, Get Memory Limit, Set Content will be added. The syscall Spawn is the core part of this update. The Spawn and the latter two syscalls: Get Memory Limit and Set Content together, implement a way to call another CKB Script in a CKB Script. Unlike the Exec syscall, Spawn saves the execution context of the current script, like posix_spawn, the parent script blocks until the child script ends.
-* [“A” Standard Extension](https://five-embeddev.com/riscv-isa-manual/latest/a.html), strictly speaking “A” Standard Extension in ckb-vm does not bring functional changes, but many existing code will be compiled with Atomic Instructions and need to be patched, while ckb-vm can implement A instructions to eliminate such work. For example, in CKB VM v2, if you write a script with rust, you can now use [log](https://crates.io/crates/log) crate directly.
 * Introduce more [macro-op fusion](https://en.wikichip.org/wiki/macro-operation_fusion) to reduce cycles consumption of scripts.
 
 


### PR DESCRIPTION
Ref https://github.com/nervosnetwork/ckb-vm/pull/510